### PR TITLE
pio from reddit with fix for server command reading bug

### DIFF
--- a/mcwrapper
+++ b/mcwrapper
@@ -199,21 +199,16 @@ function read_server_property {
 }
 
 function read_command {
-	# read from the command pipe
-	exec < "$COMMAND_PIPE"
-	
-	# initialize INPUT to be empty string
-	INPUT=""
-	
-	while [[ "$INPUT" != 'stop' ]]; do
-    read INPUT
-  	echo $INPUT
-
-  	# if the user said "stop" then exit after the command completes.
-  	if [[ "$INPUT" = "stop" ]]; then
-  		clean_up
-  		exit 0
-  	fi
+	while true
+	do
+		INPUT=$( cat $COMMAND_PIPE )
+		echo $INPUT
+		
+		# if the user said "stop" then exit after the command completes.
+		if [[ "$INPUT" = "stop" ]]; then
+			clean_up
+			exit 0
+		fi
 	done
 }
 


### PR DESCRIPTION
Hey man, I posted on your reddit thread.  

I love the script but I experienced a weird problem where the read_command() function's "read" statement was firing instantly and infinitely beginning every time text was put in to the FIFO.  As a result, my server log became full of "Unknown console command" messages.  

This was on Ubuntu 11.04 amd64.  

I'm not sure why your method didn't work, but I re-implemented the read_command function, avoiding using exec to read from stdin.  After doing this, it works perfectly for me.  Check it out, this is probably a more portable since it uses less exotic methods.
